### PR TITLE
Fix overflow in int2ascii

### DIFF
--- a/imghdr.nim
+++ b/imghdr.nim
@@ -71,10 +71,12 @@
 
 proc int2ascii(i : seq[int8]): string = 
     ## Converts a sequence of integers into a string containing all of the characters.
+
+    var h = high(uint8).int
     
     var s : string = ""
     for j, value in i:
-        s = s & (chr(int(value)))
+        s = s & chr(value %% h)
     return s
 
 

--- a/imghdr.nim
+++ b/imghdr.nim
@@ -72,7 +72,7 @@
 proc int2ascii(i : seq[int8]): string = 
     ## Converts a sequence of integers into a string containing all of the characters.
 
-    var h = high(uint8).int
+    let h = high(uint8).int + 1
     
     var s : string = ""
     for j, value in i:


### PR DESCRIPTION
int2ascii assumed the first bytes in the file are less than 0x10,
crashed if the assumption didn't hold.
Using uint8 instead of int8 throughout the lib might be cleaner, but would change the API.

fixes #3 